### PR TITLE
Fix bash flag typo

### DIFF
--- a/languages/bash.sh
+++ b/languages/bash.sh
@@ -233,7 +233,7 @@ str1 > str2               # str1 is greater than str2 (alphabetically)
 -e file                   # file exists; same -a
 -f file                   # file exists and is a regular file (i.e., not a directory or other special type of file)
 -r file                   # you have read permission
--r file                   # file exists and is not empty
+-s file                   # file exists and is not empty
 -w file                   # your have write permission
 -x file                   # you have execute permission on file, or directory search permission if it is a directory
 -N file                   # file was modified since it was last read


### PR DESCRIPTION
This had `-r` twice, but this one should be `-s`