### PR TITLE
Remove duplicate defaultProps explanation

### DIFF
--- a/frontend/react.js
+++ b/frontend/react.js
@@ -337,8 +337,3 @@ MyComponent.propTypes = {
     }
   })
 };
-
-// Specifies the default values for props:
-MyComponent.defaultProps = {
-  name: 'Stranger'
-};


### PR DESCRIPTION
This PR will remove a duplicate definition for defaultProps, since it originally appears on [L178-L182](https://github.com/LeCoupa/awesome-cheatsheets/blob/master/frontend/react.js#L178-L182)