### PR TITLE
Angular: clarify meaning of `@Injectable` decorator

### DIFF
--- a/frontend/angular-io.js
+++ b/frontend/angular-io.js
@@ -185,8 +185,7 @@ class MyDirective() {}
 @Pipe({...})
 class MyPipe() {} 
 
-// Declares that a class has dependencies that should be injected into the constructor when the 
-// dependency injector is creating an instance of this class.
+// Declares that a class can be injected into the constructor of another class by the dependency injector.
 @Injectable()
 class MyService() {}  
 


### PR DESCRIPTION
Hi, that's a great cheat sheet for Angular but I wanted to make one suggestion:

>  Declares that a class has dependencies that should be injected into the constructor when the dependency injector is creating an instance of this class.

This is not really the intended meaning of `@Injectable`, as I understand from the docs (in fact it is the opposite): https://angular.io/api/core/Injectable

> A marker metadata that marks a class as available to Injector for creation.

> The @Injectable decorator identifies services and other classes that are intended to be injected. It can also be used to configure a provider for those services.

I have tried to clarify this in the PR.