### PR TITLE
Fix meaning of HTML <em></em> tag

### DIFF
--- a/frontend/html5.html
+++ b/frontend/html5.html
@@ -38,7 +38,7 @@
 
 
 <strong></strong> and <b></b>                     <!-- Makes text contained in the tag as bold -->
-<em></em> and <i></i>                             <!-- Alternative way to make the text contained in the tag as bold -->
+<em></em> and <i></i>                             <!-- Alternative way to make the text contained in the tag as italic -->
 <strike></strike>                                 <!-- creates a strike through the text element -->
 <pre></pre>                                       <!-- Preformatted monospace text block with some spacing intact -->
 <blockquote></blockquote>                         <!-- Contains long paragraphs of quotations often cited -->


### PR DESCRIPTION
Texts  between `<em></em>` or `<i></i>` tags are italic, not bold.