### PR TITLE
Minor edits to the django start project steps

### DIFF
--- a/backend/django.py
+++ b/backend/django.py
@@ -99,12 +99,12 @@ django-admin version                     # display the current django version
 # *****************************************************************************
 
 
-# 1. $ curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py; python3 get-pip.py
-# 2. $ pip install django						
-# 3. $ pip install virtualenv
-# 4. $ mkdir django-projects
-# 5. $ cd django-projects  
-# 6. $ virtualenv venv 								
-# 7. $ source venv/bin/activate								
+# 1. $ curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py; python3 get-pip.py						
+# 2. $ pip install virtualenv
+# 3. $ mkdir django-projects
+# 4. $ cd django-projects  
+# 5. $ virtualenv venv 								
+# 6. $ source venv/bin/activate	
+# 7. $ pip install django							
 # 8. $ django-admin startproject myproject					
 # 9. $ python manage.py runserver


### PR DESCRIPTION
django start project steps reordered, in order to install django in env instead of /usr