### PR TITLE
refactor(docs): updated link for kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Feel free to take a look. You might learn new things. They have been designed to
 
 - [Docker](tools/docker.sh)
 - [Heroku CLI](tools/heroku.sh)
-- [Kubernetes](tools/kubernetes.sh)
+- [Kubernetes](tools/kubernetes.md)
 - [Nanobox Boxfile](tools/nanobox_boxfile.yml)
 - [Nanobox CLI](tools/nanobox_cli.sh)
 - [Nginx](tools/nginx.sh)


### PR DESCRIPTION
Broken link for `tools/kubernetes` is resolved