### PR TITLE
Remove duplicate description from Python Basic Datatypes

### DIFF
--- a/languages/python.md
+++ b/languages/python.md
@@ -34,7 +34,6 @@
 | char | Characters [a, b, @, !, `] |
 | str | Strings [abc, AbC, A@B, sd!, `asa] |
 | bool | Boolean Values [True, False] |
-| char | Characters [a, b, @, !, `] |
 | complex | Complex numbers [2+3j, 4-1j] |
 
 <br>


### PR DESCRIPTION
Thanks for great cheat sheets!

I found a duplicate description in python cheat sheet.
Please review and merge it.

Thanks,
tosi