### PR TITLE
use venv in python standard library instead of virtualenv

### DIFF
--- a/backend/django.py
+++ b/backend/django.py
@@ -109,12 +109,11 @@ django-admin version                     # display the current django version
 
 
 # 1. $ curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py; python3 get-pip.py						
-# 2. $ pip install virtualenv
-# 3. $ mkdir django-projects
-# 4. $ cd django-projects  
-# 5. $ virtualenv venv 								
-# 6. $ source venv/bin/activate	
-# 7. $ pip install django							
-# 8. $ django-admin startproject myproject
-# 9. $ django-admin startapp myapp
-# 10. $ python manage.py runserver
+# 2. $ mkdir django-projects
+# 3. $ cd django-projects  
+# 4. $ python3 -m venv .venv 								
+# 5. $ source .venv/bin/activate	
+# 6. $ pip install django							
+# 7. $ django-admin startproject myproject
+# 8. $ django-admin startapp myapp
+# 9. $ python manage.py runserver


### PR DESCRIPTION
Since Python 3.3, a subset of virtualenv has been integrated into the standard library under the [venv module](https://docs.python.org/3/library/venv.html).

So we don`t need to install an extra virtualenv library.