### PR TITLE
Update readme: fix grammatical error in java.md

### DIFF
--- a/languages/java.md
+++ b/languages/java.md
@@ -286,7 +286,7 @@ for(dataType item : array) {
 
 ### ACCESS MODIFIERS
 
-1. defualt(No keyword required)
+1. defaut(No keyword required)
 2. private
 3. public
 4. protected

--- a/languages/java.md
+++ b/languages/java.md
@@ -286,7 +286,7 @@ for(dataType item : array) {
 
 ### ACCESS MODIFIERS
 
-1. defaut(No keyword required)
+1. default(No keyword required)
 2. private
 3. public
 4. protected


### PR DESCRIPTION
# An grammatical error in the Java content, in the ACCESS MODIFIERS section.

Change:

    1. defualt(No keyword required)
To:

    1 . default(No keyword required)