### PR TITLE
added commands for entire array/value at index to bash.sh

### DIFF
--- a/languages/bash.sh
+++ b/languages/bash.sh
@@ -218,7 +218,6 @@ array[2]=valC
 array=([2]=valC [0]=valA [1]=valB)  # another way
 array=(valA valB valC) # and another
 ${array[@]} # list contents
-${array[i]} # value at index i (0-based)
 
 ${array[i]}                  # displays array's value for this index. If no index is supplied, array element 0 is assumed
 ${#array[i]}                 # to find out the length of any element in the array

--- a/languages/bash.sh
+++ b/languages/bash.sh
@@ -259,6 +259,17 @@ $(UNIX command)              # command substitution: runs the command and return
 
 typeset -l <x>                 # makes variable local - <x> must be an interger
 
+#########################
+# POSIX Character Classes
+#########################
+
+[:alnum:]		# Alphanumeric characters
+[:alpha:]		# Alphabetic characters
+[:digit:]		# Numerals
+[:upper:]		# Uppercase alphabetic characters
+[:lower:]		# Lowercase alphabetic characters
+[!characters]	# Matches any character that is not a member of the set characters
+
 ##############################################################################
 # FUNCTIONS
 ##############################################################################

--- a/languages/bash.sh
+++ b/languages/bash.sh
@@ -216,7 +216,9 @@ array[0]=valA                # how to define an array
 array[1]=valB
 array[2]=valC
 array=([2]=valC [0]=valA [1]=valB)  # another way
-array=(valA valB valC)              # and another
+array=(valA valB valC) # and another
+${array[@]} # list contents
+${#array[i]} # value at index i (0-based)
 
 ${array[i]}                  # displays array's value for this index. If no index is supplied, array element 0 is assumed
 ${#array[i]}                 # to find out the length of any element in the array


### PR DESCRIPTION
Noticed there were no commands for showing all values in an array and only 1 value at a given index in bash.sh cheatsheet in the Variables section, otherwise cheat sheets are awesome 💯